### PR TITLE
Fixed memory corruption

### DIFF
--- a/reflect.c
+++ b/reflect.c
@@ -271,7 +271,7 @@ static void ReadInterfaces(const uint32_t* pui32Tokens,
         psClassTypes[i].ui16ID = (uint16_t)i;
     }
 
-    psClassInstances = malloc(sizeof(ClassType) * ui32ClassInstanceCount);
+    psClassInstances = malloc(sizeof(ClassInstance) * ui32ClassInstanceCount);
     for(i=0; i<ui32ClassInstanceCount; ++i)
     {
         pui16ClassInstances = ReadClassInstance(pui32FirstInterfaceToken, pui16ClassInstances, psClassInstances+i);


### PR DESCRIPTION
When allocating space for an array of ClassInstance's an array of
ClassType was allocated instead and implicitly cast from void\* to
ClassInstance*. ClassType is smaller
than ClassInstance therefore the allocated array is too small and
writing the full array results in memory corruption.
