### PR TITLE
Triangle tessellation bug fix.

### DIFF
--- a/src/toGLSL.c
+++ b/src/toGLSL.c
@@ -457,7 +457,7 @@ void TranslateToGLSL(HLSLCrossCompilerContext* psContext, GLLang* planguage,cons
     if(psShader->eShaderType == HULL_SHADER)
     {
         int haveInstancedForkPhase = 0;			// Do we have an instanced fork phase?
-		int isCurrentForkPhasedInstanced = 0;	// Is the current fork phase instanced?
+        int isCurrentForkPhasedInstanced = 0;	// Is the current fork phase instanced?
         uint32_t forkIndex = 0;
 
         ConsolidateHullTempVars(psShader);
@@ -481,7 +481,7 @@ void TranslateToGLSL(HLSLCrossCompilerContext* psContext, GLLang* planguage,cons
 
         if(psShader->ui32HSControlPointInstrCount)
         {
-			SetDataTypes(psContext, psShader->psHSControlPointPhaseInstr, psShader->ui32HSControlPointInstrCount);
+            SetDataTypes(psContext, psShader->psHSControlPointPhaseInstr, psShader->ui32HSControlPointInstrCount);
 
             bcatcstr(glsl, "void control_point_phase()\n{\n");
             psContext->indent++;
@@ -506,14 +506,14 @@ void TranslateToGLSL(HLSLCrossCompilerContext* psContext, GLLang* planguage,cons
                 if(psShader->apsHSForkPhaseDecl[forkIndex][i].eOpcode == OPCODE_DCL_HS_FORK_PHASE_INSTANCE_COUNT)
                 {
                     haveInstancedForkPhase = 1;
-					isCurrentForkPhasedInstanced = 1;
+                    isCurrentForkPhasedInstanced = 1;
                 }
             }
 
             bformata(glsl, "void fork_phase%d()\n{\n", forkIndex);
             psContext->indent++;
 
-			SetDataTypes(psContext, psShader->apsHSForkPhaseInstr[forkIndex], psShader->aui32HSForkInstrCount[forkIndex]-1);
+            SetDataTypes(psContext, psShader->apsHSForkPhaseInstr[forkIndex], psShader->aui32HSForkInstrCount[forkIndex]-1);
 
                 if(isCurrentForkPhasedInstanced)
                 {
@@ -535,12 +535,12 @@ void TranslateToGLSL(HLSLCrossCompilerContext* psContext, GLLang* planguage,cons
                     psContext->indent--;
                     AddIndentation(psContext);
 
-					if(isCurrentForkPhasedInstanced)
-					{
-						bcatcstr(glsl, "}\n");
-					}
+                    if(isCurrentForkPhasedInstanced)
+                    {
+                        bcatcstr(glsl, "}\n");
+                    }
 
-					if(psContext->havePostShaderCode[psContext->currentPhase])
+                    if(psContext->havePostShaderCode[psContext->currentPhase])
                     {
 #ifdef _DEBUG
                         AddIndentation(psContext);
@@ -552,7 +552,7 @@ void TranslateToGLSL(HLSLCrossCompilerContext* psContext, GLLang* planguage,cons
                         bcatcstr(glsl, "//--- End post shader code ---\n");
 #endif
                     }
-			}
+            }
 
             psContext->indent--;
             bcatcstr(glsl, "}\n");


### PR DESCRIPTION
In the hull shader, my previous fix was not using post shader code to write back gl_TessLevels. This only appeared to be a bug with triangle tessellation, where fork_phase1 (glTessLevelInner) was not instanced, and thus not writing out glTessLevelInner.

I am not 100% sure if this is the correct fix, but it does fix the case I have. I will probably add a few more test cases in for tessellation as I have noticed another issue with triangle tessellation, though the errors only seem to occur on link.

The shader I've used for this fix is basically a modified version of your tessellation.hlsl, the code is this:

```
struct IA_OUTPUT
{
    float4 cpoint : CPOINT;
    float4 colour : COLOR;
};

struct VS_OUTPUT
{
    float4 cpoint : SV_Position;
    float4 colour : COLOR;
};

matrix World;
matrix View;
matrix Projection;

VS_OUTPUT VS(IA_OUTPUT input)
{
    VS_OUTPUT output;

    output.cpoint = mul( input.cpoint, World );
    output.cpoint = mul( output.cpoint, View );
    output.cpoint = mul( output.cpoint, Projection );

    output.colour = input.colour;
    return output;
}

struct HS_CONSTANT_OUTPUT
{
    float edges[3] : SV_TessFactor;
    float innerEdges: SV_InsideTessFactor;
};

struct HS_OUTPUT
{
    float4 cpoint : SV_Position;
    float4 colour : COLOR;
};

float InnerFactor = 1.0f;
float OuterFactor = 1.0f;

HS_CONSTANT_OUTPUT HSConst()
{
    HS_CONSTANT_OUTPUT output;

    output.innerEdges = InnerFactor;
    output.edges[0] = OuterFactor;
    output.edges[1] = OuterFactor;
    output.edges[2] = OuterFactor;

    return output;
}

[domain("tri")]
[partitioning("integer")]
[outputtopology("triangle_ccw")]
[outputcontrolpoints(3)]
[patchconstantfunc("HSConst")]
HS_OUTPUT HS(InputPatch<VS_OUTPUT, 3> ip, uint id : SV_OutputControlPointID)
{
    HS_OUTPUT output;
    output.cpoint = ip[id].cpoint * 1.01f;
    output.colour = ip[id].colour * 1.01f;
    return output;
}

struct DS_OUTPUT
{
    float4 position : SV_Position;
    float4 colour : COLOR;
};


float4 interpolate(float3 TessCoord, float4 v0, float4 v1, float4 v2 )
{
    float4 a = TessCoord.x * v0;
    float4 b = TessCoord.y * v1;
    float4 c = TessCoord.z * v2;
    return a + b + c;
}

[domain("tri")]
DS_OUTPUT DS(HS_CONSTANT_OUTPUT input, OutputPatch<HS_OUTPUT, 3> op, float3 uv : SV_DomainLocation)
{
    DS_OUTPUT output;

    output.position = interpolate(uv, op[0].cpoint, op[1].cpoint, op[2].cpoint);

    output.colour = interpolate(uv, op[0].colour, op[1].colour, op[2].colour);

    return output;
}


float4 PS(DS_OUTPUT input) : SV_Target0
{
    return input.colour;
}
```
