### PR TITLE
Added a new flag HLSLCC_FLAG_COMBINE_TEXTURE_SAMPLERS which creates a ne...

### DIFF
--- a/include/hlslcc.h
+++ b/include/hlslcc.h
@@ -311,6 +311,17 @@ typedef enum TESSELLATOR_OUTPUT_PRIMITIVE
     TESSELLATOR_OUTPUT_TRIANGLE_CCW  = 4
 } TESSELLATOR_OUTPUT_PRIMITIVE;
 
+typedef struct TextureSamplerPair_TAG
+{
+    char Name[MAX_REFLECT_STRING_LENGTH];
+} TextureSamplerPair;
+
+typedef struct TextureSamplerInfo_TAG
+{
+    uint32_t ui32NumTextureSamplerPairs;
+    TextureSamplerPair aTextureSamplerPair[MAX_RESOURCE_BINDINGS];
+} TextureSamplerInfo;
+
 typedef struct ShaderInfo_TAG
 {
     uint32_t ui32MajorVersion;
@@ -386,6 +397,7 @@ typedef struct
     char* sourceCode;
     ShaderInfo reflection;
     GLLang GLSLLanguage;
+    TextureSamplerInfo textureSamplerInfo;    // HLSLCC_FLAG_COMBINE_TEXTURE_SAMPLERS fills this out
 } GLSLShader;
 
 /*HLSL constant buffers are treated as default-block unform arrays by default. This is done
@@ -419,6 +431,9 @@ static const unsigned int HLSLCC_FLAG_DUAL_SOURCE_BLENDING = 0x40;
 static const unsigned int HLSLCC_FLAG_INOUT_SEMANTIC_NAMES = 0x80;
 //If set, shader inputs and outputs are declared with their semantic name appended.
 static const unsigned int HLSLCC_FLAG_INOUT_APPEND_SEMANTIC_NAMES = 0x100;
+
+//If set, combines texture/sampler pairs used together into samplers named "texturename_X_samplername".
+static const unsigned int HLSLCC_FLAG_COMBINE_TEXTURE_SAMPLERS = 0x200;
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/internal_includes/structs.h
+++ b/src/internal_includes/structs.h
@@ -78,6 +78,7 @@ typedef struct Instruction_TAG
 } Instruction;
 
 static enum{ MAX_IMMEDIATE_CONST_BUFFER_VEC4_SIZE = 1024};
+static enum{ MAX_TEXTURE_SAMPLERS_PAIRS = 32};
 
 typedef struct ICBVec4_TAG {
 	uint32_t a;
@@ -147,6 +148,9 @@ typedef struct Declaration_TAG
     uint32_t ui32TableLength;
 
 	uint32_t ui32IsShadowTex;
+
+    uint32_t ui32SamplerUsed[MAX_TEXTURE_SAMPLERS_PAIRS];
+    uint32_t ui32SamplerUsedCount;
 } Declaration;
 
 static enum {MAX_TEMP_VEC4 = 512};
@@ -245,6 +249,7 @@ typedef struct Shader_TAG
 
 	ShaderVarType sGroupSharedVarType[MAX_GROUPSHARED];
 
+    TextureSamplerInfo textureSamplerInfo;
 } Shader;
 
 static const uint32_t MAIN_PHASE = 0;

--- a/src/internal_includes/toGLSLOperand.h
+++ b/src/internal_includes/toGLSLOperand.h
@@ -23,6 +23,9 @@ uint32_t IsSwizzleReplacated(const Operand* psOperand);
 
 void TextureName(HLSLCrossCompilerContext* psContext, const uint32_t ui32RegisterNumber, const int bZCompare);
 
+bstring TextureSamplerName(ShaderInfo* psShaderInfo, const uint32_t ui32TextureRegisterNumber, const uint32_t ui32SamplerRegisterNumber, const int bZCompare);
+void ConcatTextureSamplerName(bstring str, ShaderInfo* psShaderInfo, const uint32_t ui32TextureRegisterNumber, const uint32_t ui32SamplerRegisterNumber, const int bZCompare);
+
 //Non-zero means the components overlap
 int CompareOperandSwizzles(const Operand* psOperandA, const Operand* psOperandB);
 

--- a/src/toGLSL.c
+++ b/src/toGLSL.c
@@ -840,6 +840,9 @@ HLSLCC_API int HLSLCC_APIENTRY TranslateHLSLFromMem(const char* shader,
         
 		memcpy(&result->reflection,&psShader->sInfo,sizeof(psShader->sInfo));
         
+		result->textureSamplerInfo.ui32NumTextureSamplerPairs = psShader->textureSamplerInfo.ui32NumTextureSamplerPairs;
+		for (i=0; i<result->textureSamplerInfo.ui32NumTextureSamplerPairs; i++)
+			strcpy(result->textureSamplerInfo.aTextureSamplerPair[i].Name, psShader->textureSamplerInfo.aTextureSamplerPair[i].Name);
 
         hlslcc_free(psShader);
 


### PR DESCRIPTION
Added a new flag HLSLCC_FLAG_COMBINE_TEXTURE_SAMPLERS which creates a new GLSL sampler for every unique texture+sampler pair used in HLSL.
The new sampler names are the texture name and sampler name delimited by '_X_'.
For example, the HLSL code "diffuseTexture.Sample(linearSampler, texcoords);" will become a GLSL sampler named "diffuseTexture_X_linearSampler".
The delimiter '_X_' is used so other code can easily split the GLSL sampler name into the original texture and sampler components.
